### PR TITLE
fix(ci): Use yarn version of 'npm ci'

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -13,8 +13,12 @@ jobs:
     steps:
       - name: Connect workflow to repository
         uses: actions/checkout@v2
+      - name: Setup NodeJS
+        uses: actions/setup-node@v2
+        with:
+          node-version: '12.x'
       - name: Install all required dependencies
-        run: npm ci
+        run: yarn install --frozen-lockfile
       - name: Build the files
         run: npm run build
       - name: Scrap and re-new the data


### PR DESCRIPTION
## Overview

This pull request fixes failed CI flow by using `yarn install` instead of `npm ci` as I've migrated to `yarn` by the last PR.