### PR TITLE
fix(build): Downgrade compilation target to ES2017 to ensure node 12 compatibilty

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,6 @@ jobs:
       - name: Connect workflow to repository
         uses: actions/checkout@v2
       - name: Install all required dependencies
-        run: npm ci
+        run: yarn install --frozen-lockfile
       - name: Lint the files
-        run: npm run lint
+        run: yarn lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,10 @@ jobs:
     steps:
       - name: Connect workflow to repository
         uses: actions/checkout@v2
+      - name: Setup NodeJS
+        uses: actions/setup-node@v2
+        with:
+          node-version: '12.x'
       - name: Install all required dependencies
         run: yarn install --frozen-lockfile
       - name: Lint the files

--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -20,9 +20,9 @@ jobs:
       - name: Install all required dependencies
         run: yarn install --frozen-lockfile
       - name: Build the files
-        run: npm run build
+        run: yarn build
       - name: Scrap and re-new the data
-        run: npm run scrap
+        run: yarn scrap
       - name: Deploy to Vercel Now
         uses: amondnet/vercel-action@v20.0.0
         with:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,9 +4,12 @@
 
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "esnext",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "target": "es2017",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    "lib": [
+      "DOM",
+      "ES2019.Array"
+    ],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */


### PR DESCRIPTION
## Overview

This pull request downgrades the TS compilation target to ES2017 to ensure Node 12 compatibility (especially optional chaining). Also replaces legacy `npm` stuff in action file.