### PR TITLE
fix: Separate actions/checkout with commit script

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -11,6 +11,8 @@ jobs:
   refresh:
     runs-on: ubuntu-latest
     steps:
+      - name: Connect to repository
+        uses: actions/checkout@v2
       - name: Setup NodeJS
         uses: actions/setup-node@v2
         with:
@@ -22,7 +24,6 @@ jobs:
       - name: Scrap and renew the data
         run: yarn scrap
       - name: Recommit the data
-        uses: actions/checkout@v2
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com


### PR DESCRIPTION
## Overview

This pull request fixes the action definition by separating `actions/checkout` from the actual commit script.