### PR TITLE
fix: Allow POST method on graphql endpoint

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -24,6 +24,27 @@
           "value": "GET"
         }
       ]
+    },
+    {
+      "source": "/api/graphql",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=86400, stale-while-revalidate"
+        },
+        {
+          "key": "Content-Type",
+          "value": "application/json; charset=utf-8"
+        },
+        {
+          "key": "Access-Control-Allow-Origin",
+          "value": "*"
+        },
+        {
+          "key": "Access-Control-Allow-Methods",
+          "value": "GET, POST"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Overview

This pull request allows `/api/graphql` to accept `POST` requests, as a part of GraphQL standards.