### PR TITLE
fix: Fix header pattern target when targeting non-graphql routes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,27 +5,6 @@
   },
   "headers": [
     {
-      "source": "/api/(.*)",
-      "headers": [
-        {
-          "key": "Cache-Control",
-          "value": "public, max-age=86400, stale-while-revalidate"
-        },
-        {
-          "key": "Content-Type",
-          "value": "application/json; charset=utf-8"
-        },
-        {
-          "key": "Access-Control-Allow-Origin",
-          "value": "*"
-        },
-        {
-          "key": "Access-Control-Allow-Methods",
-          "value": "GET"
-        }
-      ]
-    },
-    {
       "source": "/api/graphql",
       "headers": [
         {
@@ -43,6 +22,27 @@
         {
           "key": "Access-Control-Allow-Methods",
           "value": "GET, POST"
+        }
+      ]
+    },
+    {
+      "source": "/api/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=86400, stale-while-revalidate"
+        },
+        {
+          "key": "Content-Type",
+          "value": "application/json; charset=utf-8"
+        },
+        {
+          "key": "Access-Control-Allow-Origin",
+          "value": "*"
+        },
+        {
+          "key": "Access-Control-Allow-Methods",
+          "value": "GET"
         }
       ]
     }

--- a/vercel.json
+++ b/vercel.json
@@ -5,6 +5,27 @@
   },
   "headers": [
     {
+      "source": "/api/((?!graphql).*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=86400, stale-while-revalidate"
+        },
+        {
+          "key": "Content-Type",
+          "value": "application/json; charset=utf-8"
+        },
+        {
+          "key": "Access-Control-Allow-Origin",
+          "value": "*"
+        },
+        {
+          "key": "Access-Control-Allow-Methods",
+          "value": "GET"
+        }
+      ]
+    },
+    {
       "source": "/api/graphql",
       "headers": [
         {
@@ -22,27 +43,6 @@
         {
           "key": "Access-Control-Allow-Methods",
           "value": "GET, POST"
-        }
-      ]
-    },
-    {
-      "source": "/api/(.*)",
-      "headers": [
-        {
-          "key": "Cache-Control",
-          "value": "public, max-age=86400, stale-while-revalidate"
-        },
-        {
-          "key": "Content-Type",
-          "value": "application/json; charset=utf-8"
-        },
-        {
-          "key": "Access-Control-Allow-Origin",
-          "value": "*"
-        },
-        {
-          "key": "Access-Control-Allow-Methods",
-          "value": "GET"
         }
       ]
     }


### PR DESCRIPTION
## Overview

This pull request changes the API header target for non-GraphQL endpoints to `/api/((?!graphql).*)`