### PR TITLE
fix: Replace nullish coalescing with OR operator

### DIFF
--- a/docs/apps.MD
+++ b/docs/apps.MD
@@ -12,7 +12,7 @@ Cari seluruh aplikasi manajemen investasi atau portal transaksi investasi yang t
 ---- | ---- | ---------
 `name` | `string` | Pola _string_ yang ingin dicari dari nama aplikasi
 `limit` | `int` | Jumlah data yang diminta
-`start` | `int` | Indeks pertama dari data yang diminta. Dimulai dari 1.
+`offset` | `int` | Indeks pertama dari data yang diminta.
 
 ### Status HTTP
 

--- a/docs/illegals.MD
+++ b/docs/illegals.MD
@@ -14,7 +14,7 @@ Cari seluruh produk investasi yang telah dinyatakan illegal oleh OJK.
 ---- | ---- | ---------
 `name` | `string` | Pola _string_ yang ingin dicari dari nama produk investasi
 `limit` | `int` | Jumlah data yang diminta
-`start` | `int` | Indeks pertama dari data yang diminta. Dimulai dari 1.
+`offset` | `int` | Indeks pertama dari data yang diminta.
 
 ### Status HTTP
 

--- a/docs/products.MD
+++ b/docs/products.MD
@@ -12,7 +12,7 @@ Cari seluruh produk reksa dana yang telah dinyatakan legal oleh OJK.
 ---- | ---- | ---------
 `name` | `string` | Pola _string_ yang ingin dicari dari nama produk reksa dana
 `limit` | `int` | Jumlah data yang diminta
-`start` | `int` | Indeks pertama dari data yang diminta. Dimulai dari 1.
+`offset` | `int` | Indeks pertama dari data yang diminta.
 
 ### Status HTTP
 
@@ -40,9 +40,7 @@ Cari sebuah produk reksa dana legal yang diizinkan oleh OJK yang memiliki ID yan
 
 **Nama** | **Tipe Data** | **Deskripsi**
 ---- | ---- | ---------
-`name` | `string` | Pola _string_ yang ingin dicari dari nama produk reksa dana
-`limit` | `int` | Jumlah data yang diminta
-`start` | `int` | Indeks pertama dari data yang diminta. Dimulai dari 1.
+`id` | `number` | ID dari produk reksa dana
 
 ### Status HTTP
 

--- a/src/services/api/app.ts
+++ b/src/services/api/app.ts
@@ -41,11 +41,7 @@ async function importData(): Promise<AppsData> {
  * application.
  */
 export async function getMany(query: Query): Promise<GetManyResult<App> > {
-  const { name } = query;
-  let { limit, offset } = query;
-
-  limit = limit ?? 0;
-  offset = offset ?? 0;
+  const { name, limit, offset } = query;
 
   const source = await importData();
 
@@ -63,13 +59,8 @@ export async function getMany(query: Query): Promise<GetManyResult<App> > {
 
   const count = apps.length;
 
-  if (!isNaN(offset)) {
-    apps = apps.slice(offset);
-  }
-
-  if (!isNaN(limit)) {
-    apps = apps.slice(0, limit);
-  }
+  apps = apps.slice(offset);
+  apps = apps.slice(0, limit);
 
   return {
     data: apps,

--- a/src/services/api/illegal.ts
+++ b/src/services/api/illegal.ts
@@ -43,11 +43,7 @@ async function importData(): Promise<IllegalInvestmentData> {
 export async function getMany(
   query: Query,
 ): Promise<GetManyResult<IllegalInvestment> > {
-  const { name } = query;
-  let { limit, offset } = query;
-
-  offset = offset ?? 0;
-  limit = limit ?? 0;
+  const { name, limit, offset } = query;
 
   const source = await importData();
 
@@ -65,13 +61,8 @@ export async function getMany(
 
   const count = investments.length;
 
-  if (!isNaN(offset)) {
-    investments = investments.slice(offset);
-  }
-
-  if (!isNaN(limit)) {
-    investments = investments.slice(0, limit);
-  }
+  investments = investments.slice(offset);
+  investments = investments.slice(0, limit);
 
   return {
     data: investments,

--- a/src/services/api/product.ts
+++ b/src/services/api/product.ts
@@ -43,11 +43,7 @@ async function importData(): Promise<ProductData> {
 export async function getMany(
   query: Query,
 ): Promise<GetManyResult<Product> > {
-  const { name } = query;
-  let { limit, offset } = query;
-
-  limit = limit ?? 0;
-  offset = offset ?? 0;
+  const { name, limit, offset } = query;
 
   const dataPath = resolve(process.cwd(), 'data', 'products.json');
 
@@ -78,13 +74,8 @@ export async function getMany(
 
   const count = products.length;
 
-  if (!isNaN(offset)) {
-    products = products.slice(offset);
-  }
-
-  if (!isNaN(limit)) {
-    products = products.slice(0, limit);
-  }
+  products = products.slice(offset);
+  products = products.slice(0, limit);
 
   return {
     data: products,

--- a/src/services/api/utils.ts
+++ b/src/services/api/utils.ts
@@ -8,21 +8,19 @@ import { Query, Params } from './const';
  * @return {Query} validated and formatted user input
  */
 export function validateQuery(query: any): Query {
-  let limit = Number(query.limit);
-  let offset = Number(query.start) - 1;
+  let limit: number | undefined = Number(query.limit);
+  let offset = Number(query.offset);
 
-  if (limit < 0) {
-    throw new ValidationError('Nilai `limit` tidak boleh negatif');
+  if (!isNaN(limit) && limit < 1) {
+    throw new ValidationError('Nilai `limit` tidak boleh lebih kecil dari 1');
   }
 
-  if (offset < 0) {
-    throw new ValidationError(
-      'Nilai `offset` tidak boleh lebih kecil dari satu',
-    );
+  if (!isNaN(limit) && offset < 0) {
+    throw new ValidationError('Nilai `offset` tidak boleh negatif');
   }
 
-  limit = limit ?? 0;
-  offset = offset ?? 0;
+  limit = limit || undefined;
+  offset = offset || 0;
 
   return {
     name: query.name,


### PR DESCRIPTION
## Overview

This pull request replaces the `??` operator with `||`. The reason for this replacement is caused by the behavior of the `??` operator which considers `NaN` to be a valid value for the left-hand operand. 

This pull request also replaces `start` with `offset` as `offset` is more commonly used than `start`.

Will fix #23 