### PR TITLE
fix(ci): Allow no-change commit to be commited to ensure deployment

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -28,7 +28,7 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add .
-          git commit -m "chore(ci): Refresh investments data"
+          git commit --allow-empty -m "chore(ci): Refresh investments data"
           git push
       - name: Deploy to Vercel Now
         uses: amondnet/vercel-action@v20.0.0


### PR DESCRIPTION
## Overview

This pull request adds `--allow-empty` flag to the CI process to allow empty commits to be commited. This will ensure that the latest data is deployed, even after merging with fresh data.